### PR TITLE
server side analyze for redis operation

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4043,6 +4043,20 @@ uint64_t getCommandFlags(client *c) {
  * other operations can be performed by the caller. Otherwise
  * if C_ERR is returned the client was destroyed (i.e. after QUIT). */
 int processCommand(client *c) {
+    if (c->argc >= 2 && c->cmd->firstkey >= 1) {
+        int first = c->cmd->firstkey;
+        int last = c->cmd->lastkey > 0 ? c->cmd->lastkey : first;
+        for (int i = first; i <= last && i < c->argc; i++) {
+            const char *keystr = c->argv[i]->ptr;
+            const char *client_ip = c->client_addr ? c->client_addr : "unknown";
+            int client_port = c->client_port;
+
+            serverLog(LL_NOTICE,
+                "[ACCESS] cmd=%s key=%s client=%s:%d",
+                c->cmd->name, keystr, client_ip, client_port);
+        }
+    }
+    
     if (!scriptIsTimedout()) {
         /* Both EXEC and scripts call call() directly so there should be
          * no way in_exec or scriptIsRunning() is 1.

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -292,6 +292,28 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
 /* SET key value [NX] [XX] [KEEPTTL] [GET] [EX <seconds>] [PX <milliseconds>]
  *     [EXAT <seconds-timestamp>][PXAT <milliseconds-timestamp>] */
 void setCommand(client *c) {
+    long long start_time = ustime();
+
+    const char *keyname = c->argv[1]->ptr;
+    const char *client_ip = c->client_addr ? c->client_addr : "unknown";
+    int client_port = c->client_port;
+
+    serverLog(LL_NOTICE, "[SET START] key=%s client=%s:%d", keyname, client_ip, client_port);
+
+    robj *val = c->argv[2];
+    setKey(c,c->db,c->argv[1],val,0);
+    signalModifiedKey(c,c->db,c->argv[1]);
+    notifyKeyspaceEvent(NOTIFY_STRING,"set",c->argv[1],c->db->id);
+    server.dirty++;
+    addReply(c,shared.ok);
+
+    long long end_time = ustime();
+    long long duration = end_time - start_time;
+
+    serverLog(LL_NOTICE,
+        "[SET END] key=%s client=%s:%d duration=%lldus timestamp=%lld",
+        keyname, client_ip, client_port, duration, start_time);
+    
     robj *expire = NULL;
     int unit = UNIT_SECONDS;
     int flags = OBJ_NO_FLAGS;
@@ -334,6 +356,28 @@ int getGenericCommand(client *c) {
 }
 
 void getCommand(client *c) {
+    long long start_time = ustime();
+
+    const char *keyname = c->argv[1]->ptr;
+    const char *client_ip = c->client_addr ? c->client_addr : "unknown";
+    int client_port = c->client_port;
+
+    serverLog(LL_NOTICE, "[GET START] key=%s client=%s:%d", keyname, client_ip, client_port);
+
+    robj *o;
+    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp])) == NULL)
+        return;
+
+    if (checkType(c,o,OBJ_STRING)) return;
+    addReplyBulk(c,o);
+
+    long long end_time = ustime();
+    long long duration = end_time - start_time;
+
+    serverLog(LL_NOTICE,
+        "[GET END] key=%s client=%s:%d duration=%lldus timestamp=%lld",
+        keyname, client_ip, client_port, duration, start_time);
+    
     getGenericCommand(c);
 }
 


### PR DESCRIPTION
##  Changes

- Modified `getCommand()` in `src/t_string.c` to:
  - Log key name
  - Log client IP and port
  - Measure and log execution duration in microseconds
  - Include timestamp of request start

- Modified `setCommand()` in `src/t_string.c` to:
  - Log the same details as above
- Modified `processCommand() in `src/server.c` to:
  - Log the same details as above

###  Results Example
- GET/SET
```
[SET START] key=foo client=127.0.0.1:60234
[SET END] key=foo client=127.0.0.1:60234 duration=95us timestamp=1715600023000
[GET START] key=foo client=127.0.0.1:60234
[GET END] key=foo client=127.0.0.1:60234 duration=41us timestamp=1715600023100
```

- processCommand
```
[ACCESS] cmd=GET key=session:123 client=127.0.0.1:53022
[ACCESS] cmd=DEL key=cache:user client=10.0.0.4:51155
[ACCESS] cmd=HGET key=orders:2025 client=192.168.1.3:51220
```

### Build and Test
```bash
make -j
src/redis-server
# In another terminal
src/redis-cli SET foo bar
src/redis-cli GET foo
```
